### PR TITLE
fix: update of delegates status at each refresh

### DIFF
--- a/docs/.vuepress/components/DelegateData.vue
+++ b/docs/.vuepress/components/DelegateData.vue
@@ -133,6 +133,7 @@ export default {
       const data = res.data.find((el) => el.username === delegate.unikid);
       delegate.rank = data.rank;
       delegate.votes = data.production.approval;
+      delegate.forger = delegate.rank < 24 ? true : false;
       if (delegate.forger) {
         // has not forged for more than 10 minutes
         if (


### PR DESCRIPTION
as indicated in the title, the delegate status (active or not) was only updated at the build (3 times a week atm)

now it will be updated every time the website is refreshed